### PR TITLE
Adding game controllers as input method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ find_package(projectM4 REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
 find_package(Poco REQUIRED COMPONENTS JSON XML Util Foundation)
 
+if(Poco_VERSION VERSION_GREATER_EQUAL 1.14.0)
+    # POCO 1.14 requires at least C++17
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(ENABLE_FREETYPE)
     find_package(Freetype)
 endif()

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ present.
 
 | Command | Keyboard | Mouse | Game Controller |
 | --- | --- | --- | --- |
-| Add a new waveform | | `ctrl` + Left |  |
-| Clear all custom waveforms | | Middle |  |
 | Toggle full screen | `ctrl` + `f` | Right | A |
 | Show/hide GUI | `esc` |  | Start |
 | Random preset | `r` |  | B |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ It will listen to audio input and produce mesmerizing visuals. Some commands are
 This project is in a bit of a transition state and is in the process of being modernized. There are many rough edges at
 present.
 
+## GUI controls
+
+
+| Command | Keyboard | Mouse | Game Controller |
+| --- | --- | --- | --- |
+| Add a new waveform | | `ctrl` + Left |  |
+| Clear all custom waveforms | | Middle |  |
+| Toggle full screen | `ctrl` + `f` | Right | A |
+| Show/hide GUI | `esc` |  | Start |
+| Random preset | `r` |  | B |
+| Next preset | `n` |  | D-Pad right |
+| Previous preset | `p` |  | D-Pad left |
+| Increase beat sensitivity | `Up` | Wheel up | D-Pad up |
+| Decrease beat sensitivity | `Down` | Wheel down | D-Pad down |
+| Toggle shuffle | `y` |  | Y |
+| Last preset | `Backspace` |  | Guide |
+| TogglePresetLocked | `Space` |  | X |
+| NextAudioDevice | `ctrl` + `i` |  | Shoulder left |
+| NextDisplay | `ctrl` + `m` |  | Shoulder right |
+| Toggle aspect ratio correction | `a` |  |  |
+| Quit | `q` |  | Back |
+
 ## Building from source
 
 ### Build and install libprojectM

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -421,11 +421,6 @@ void RenderLoop::MouseDownEvent(const SDL_MouseButtonEvent& event)
         case SDL_BUTTON_RIGHT:
             _sdlRenderingWindow.ToggleFullscreen();
             break;
-
-        case SDL_BUTTON_MIDDLE:
-            projectm_touch_destroy_all(_projectMHandle);
-            poco_debug(_logger, "Cleared all custom waveforms.");
-            break;
     }
 }
 

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -33,8 +33,6 @@ void RenderLoop::Run()
 
     _projectMWrapper.DisplayInitialPreset();
 
-    _controller = _sdlRenderingWindow.FindController();
-
     while (!_wantsToQuit)
     {
         limiter.TargetFPS(_projectMWrapper.TargetFPS());
@@ -53,10 +51,6 @@ void RenderLoop::Run()
         // Pass projectM the actual FPS value of the last frame.
         _projectMWrapper.UpdateRealFPS(limiter.FPS());
     }
-
-    //Close game controller
-    SDL_GameControllerClose(_controller);
-    _controller = nullptr;
 
     notificationCenter.removeObserver(_quitNotificationObserver);
 
@@ -113,12 +107,14 @@ void RenderLoop::PollEvents()
                 break;
 
             case SDL_CONTROLLERDEVICEADDED:
-                ControllerAdd(event.cdevice.which);
+                poco_debug(_logger, "Controller added event received");
+                _sdlRenderingWindow.ControllerAdd(event.cdevice.which);
 
                 break;
 
             case SDL_CONTROLLERDEVICEREMOVED:
-                ControllerRemove(event.cdevice.which);
+                poco_debug(_logger, "Controller remove event received");
+                _sdlRenderingWindow.ControllerRemove(event.cdevice.which);
 
                 break;
 
@@ -441,30 +437,10 @@ void RenderLoop::MouseUpEvent(const SDL_MouseButtonEvent& event)
     }
 }
 
-void RenderLoop::ControllerAdd(const int id )
-{
-    if (!_controller)
-    {
-        _controller = SDL_GameControllerOpen(id);
-    }
-    poco_debug(_logger, "Controller added!");
-}
-
-void RenderLoop::ControllerRemove(const int id )
-{
-    if (_controller && id == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(_controller)))
-    {
-        SDL_GameControllerClose(_controller);
-        _controller = _sdlRenderingWindow.FindController();
-    }
-    poco_debug(_logger, "Controller removed!");
-}
-
 void RenderLoop::ControllerDownEvent(const SDL_Event& event)
 {
-    if (!_controller || event.cdevice.which != SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(_controller)))
+    if (!_sdlRenderingWindow.ControllerIsOurs(event.cdevice.which) )
     {
-        poco_debug(_logger, "No controller initialized");
         return;
     }
 

--- a/src/RenderLoop.cpp
+++ b/src/RenderLoop.cpp
@@ -33,6 +33,8 @@ void RenderLoop::Run()
 
     _projectMWrapper.DisplayInitialPreset();
 
+    _controller = _sdlRenderingWindow.FindController();
+
     while (!_wantsToQuit)
     {
         limiter.TargetFPS(_projectMWrapper.TargetFPS());
@@ -51,6 +53,10 @@ void RenderLoop::Run()
         // Pass projectM the actual FPS value of the last frame.
         _projectMWrapper.UpdateRealFPS(limiter.FPS());
     }
+
+    //Close game controller
+    SDL_GameControllerClose(_controller);
+    _controller = nullptr;
 
     notificationCenter.removeObserver(_quitNotificationObserver);
 
@@ -103,6 +109,26 @@ void RenderLoop::PollEvents()
                 {
                     MouseUpEvent(event.button);
                 }
+
+                break;
+
+            case SDL_CONTROLLERDEVICEADDED:
+                ControllerAdd(event.cdevice.which);
+
+                break;
+
+            case SDL_CONTROLLERDEVICEREMOVED:
+                ControllerRemove(event.cdevice.which);
+
+                break;
+
+            case SDL_CONTROLLERBUTTONDOWN:
+                ControllerDownEvent(event);
+
+                break;
+
+            case SDL_CONTROLLERBUTTONUP:
+                ControllerUpEvent(event);
 
                 break;
 
@@ -413,6 +439,110 @@ void RenderLoop::MouseUpEvent(const SDL_MouseButtonEvent& event)
     {
         _mouseDown = false;
     }
+}
+
+void RenderLoop::ControllerAdd(const int id )
+{
+    if (!_controller)
+    {
+        _controller = SDL_GameControllerOpen(id);
+    }
+    poco_debug(_logger, "Controller added!");
+}
+
+void RenderLoop::ControllerRemove(const int id )
+{
+    if (_controller && id == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(_controller)))
+    {
+        SDL_GameControllerClose(_controller);
+        _controller = _sdlRenderingWindow.FindController();
+    }
+    poco_debug(_logger, "Controller removed!");
+}
+
+void RenderLoop::ControllerDownEvent(const SDL_Event& event)
+{
+    if (!_controller || event.cdevice.which != SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(_controller)))
+    {
+        poco_debug(_logger, "No controller initialized");
+        return;
+    }
+
+    switch (event.cbutton.button)
+    {
+        case SDL_CONTROLLER_BUTTON_A:
+            _sdlRenderingWindow.ToggleFullscreen();
+            poco_debug(_logger, "A pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_B:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::RandomPreset, _keyStates._shiftPressed));
+            poco_debug(_logger, "B pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_X:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::TogglePresetLocked));
+            poco_debug(_logger, "X pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_Y:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::ToggleShuffle));
+            poco_debug(_logger, "Y pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_BACK:
+            _wantsToQuit = true;
+            poco_debug(_logger, "Back pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_GUIDE:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::LastPreset, _keyStates._shiftPressed));
+            poco_debug(_logger, "Guide pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_START:
+            _projectMGui.Toggle();
+            _sdlRenderingWindow.ShowCursor(_projectMGui.Visible());
+            poco_debug(_logger, "Start pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+            _audioCapture.NextAudioDevice();
+            poco_debug(_logger, "Shoulder left pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+            _sdlRenderingWindow.NextDisplay();
+            poco_debug(_logger, "Shoulder right pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+            // Increase beat sensitivity
+            _projectMWrapper.ChangeBeatSensitivity(0.05f);
+            poco_debug(_logger, "DPad up pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+            // Decrease beat sensitivity
+            _projectMWrapper.ChangeBeatSensitivity(-0.05f);
+            poco_debug(_logger, "DPad down pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::PreviousPreset, _keyStates._shiftPressed));
+            poco_debug(_logger, "DPad left pressed!");
+            break;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+            Poco::NotificationCenter::defaultCenter().postNotification(new PlaybackControlNotification(PlaybackControlNotification::Action::NextPreset, _keyStates._shiftPressed));
+            poco_debug(_logger, "DPad right pressed!");
+            break;
+    }
+}
+
+void RenderLoop::ControllerUpEvent(const SDL_Event& event)
+{
+
 }
 
 void RenderLoop::QuitNotificationHandler(const Poco::AutoPtr<QuitNotification>& notification)

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -62,18 +62,6 @@ protected:
     void MouseUpEvent(const SDL_MouseButtonEvent& event);
 
     /**
-     * @brief Handles SDL game controller add events (plugin in a new controller) events.
-     * @param id The added controller id
-     */
-    void ControllerAdd( int id );
-
-    /**
-     * @brief Handles SDL game controller remove events.
-     * @param id The removed controller id
-     */
-    void ControllerRemove( int id );
-
-    /**
      * @brief Handles SDL game controller button down events.
      * @param event The controller button event
      */
@@ -114,6 +102,4 @@ protected:
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _userConfig; //!< View of the "projectM" configuration subkey in the "user" configuration.
 
     Poco::Logger& _logger{Poco::Logger::get("RenderLoop")}; //!< The class logger.
-
-    SDL_GameController *_controller;
 };

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -62,6 +62,30 @@ protected:
     void MouseUpEvent(const SDL_MouseButtonEvent& event);
 
     /**
+     * @brief Handles SDL game controller add events (plugin in a new controller) events.
+     * @param id The added controller id
+     */
+    void ControllerAdd( int id );
+
+    /**
+     * @brief Handles SDL game controller remove events.
+     * @param id The removed controller id
+     */
+    void ControllerRemove( int id );
+
+    /**
+     * @brief Handles SDL game controller button down events.
+     * @param event The controller button event
+     */
+    void ControllerDownEvent(const SDL_Event& event);
+
+    /**
+     * @brief Handles SDL game controller button up events.
+     * @param event The controller button event
+     */
+    void ControllerUpEvent(const SDL_Event& event);
+
+    /**
      * @brief Handler for quit notifications.
      * @param notification The received notification.
      */
@@ -90,4 +114,6 @@ protected:
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _userConfig; //!< View of the "projectM" configuration subkey in the "user" configuration.
 
     Poco::Logger& _logger{Poco::Logger::get("RenderLoop")}; //!< The class logger.
+
+    SDL_GameController *_controller;
 };

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -196,7 +196,7 @@ void SDLRenderingWindow::NextDisplay()
 
 void SDLRenderingWindow::CreateSDLWindow()
 {
-    SDL_InitSubSystem(SDL_INIT_VIDEO);
+    SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
 
     int width{_config->getInt("width", 800)};
     int height{_config->getInt("height", 600)};
@@ -307,7 +307,7 @@ void SDLRenderingWindow::DestroySDLWindow()
     SDL_DestroyWindow(_renderingWindow);
     _renderingWindow = nullptr;
 
-    SDL_QuitSubSystem(SDL_INIT_VIDEO);
+    SDL_QuitSubSystem(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
 }
 
 void SDLRenderingWindow::DumpOpenGLInfo()
@@ -460,4 +460,22 @@ void SDLRenderingWindow::OnConfigurationPropertyRemoved(const std::string& key)
     {
         UpdateWindowTitle();
     }
+}
+
+SDL_GameController* SDLRenderingWindow::FindController() {
+    //Check for joysticks
+    if( SDL_NumJoysticks() < 1 )
+    {
+        poco_debug(_logger, "No joysticks connected");
+    }
+
+    //For simplicity, we’ll only be setting up and tracking a single
+    //controller at a time
+    for (int i = 0; i < SDL_NumJoysticks(); i++) {
+        if (SDL_IsGameController(i)) {
+            return SDL_GameControllerOpen(i);
+        }
+    }
+
+    return nullptr;
 }

--- a/src/SDLRenderingWindow.h
+++ b/src/SDLRenderingWindow.h
@@ -102,6 +102,24 @@ public:
      */
     SDL_GameController* FindController();
 
+    /**
+     * @brief Handles SDL game controller add events (plugin in a new controller) events.
+     * @param id The added controller id
+     */
+    void ControllerAdd(const int id );
+
+    /**
+     * @brief Handles SDL game controller remove events.
+     * @param id The removed controller id
+     */
+    void ControllerRemove(const int id );
+
+    /**
+     * @brief Returns true if the given controller is initialized and the one we currently use.
+     * @param id The removed controller id
+     */
+    bool ControllerIsOurs(const int id );
+
 protected:
 
     /**
@@ -162,6 +180,7 @@ protected:
 
     bool _fullscreen{ false };
 
+    SDL_GameController *_controller;
 };
 
 

--- a/src/SDLRenderingWindow.h
+++ b/src/SDLRenderingWindow.h
@@ -96,6 +96,12 @@ public:
 
     SDL_GLContext GetGlContext() const;
 
+    /**
+     * @brief Returns the ID of the first game controller found
+     * @return SDL_GameController * Returns a gamecontroller identifier or NULL
+     */
+    SDL_GameController* FindController();
+
 protected:
 
     /**

--- a/src/resources/projectMSDL.properties.in
+++ b/src/resources/projectMSDL.properties.in
@@ -142,11 +142,6 @@ logging.channels.async.channel = split
 # Default logging settings.
 logging.loggers.root.channel = async
 
-# Set log level to debug for all components
-#logging.loggers.root.level = debug
-logging.loggers.root.level = information
-
-
 # You can configure log levels, channels etc. for each message source (logger) individually.
 # See https://docs.pocoproject.org/current/Poco.Util.LoggingConfigurator.html for details.
 # Example:

--- a/src/resources/projectMSDL.properties.in
+++ b/src/resources/projectMSDL.properties.in
@@ -102,11 +102,6 @@ projectM.aspectCorrectionEnabled = true
 # For detailed information on how to configure logging, please refer to the POCO documentation:
 # https://docs.pocoproject.org/current/Poco.Util.LoggingConfigurator.html
 
-# Set log level to debug for all components
-#logging.loggers.root.level = debug
-
-
-
 ### Logging configuration
 
 # Verbose log format, includes process/thread ID, source etc.
@@ -145,8 +140,12 @@ logging.channels.async.class = AsyncChannel
 logging.channels.async.channel = split
 
 # Default logging settings.
-logging.loggers.root.level = information
 logging.loggers.root.channel = async
+
+# Set log level to debug for all components
+#logging.loggers.root.level = debug
+logging.loggers.root.level = information
+
 
 # You can configure log levels, channels etc. for each message source (logger) individually.
 # See https://docs.pocoproject.org/current/Poco.Util.LoggingConfigurator.html for details.


### PR DESCRIPTION
I had a Bluetooth joypad lying around and though that it would be handy to be able to remote control the projectM frontend.

As SDL provides everything needed to handle game controller it was straight forward to add it. I didn't add SDL controller class or so, just extended the SDL window class. Feel free to refactor that if you think this is messy.

Tested on GNU/Linux, Debian Sid, Gnome3

Code comes mainly from this tutorial: https://lazyfoo.net/tutorials/SDL/19_gamepads_and_joysticks/index.php