### PR TITLE
Adding file/folder drop support

### DIFF
--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -76,7 +76,6 @@ void ProjectMSDLApplication::initialize(Poco::Util::Application& self)
                 {
                     loadConfiguration(configFilePath.toString(), PRIO_DEFAULT);
                 }
-
             }
         }
     }
@@ -202,6 +201,14 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              false, "<0/1>", true)
                           .binding("projectM.shuffleEnabled", _commandLineOverrides));
 
+    options.addOption(Option("skipToDropped", "", "Skip to drag & dropped presets",
+                             false, "<0/1>", true)
+                          .binding("projectM.skipToDropped", _commandLineOverrides));
+
+    options.addOption(Option("droppedFolderOverride", "", "When dropping a folder, clear the playlist and add all presets from the folder.",
+                             false, "<0/1>", true)
+                          .binding("projectM.droppedFolderOverride", _commandLineOverrides));
+
     options.addOption(Option("presetDuration", "", "Preset duration. Any number > 1, default 30.",
                              false, "<number>", true)
                           .binding("projectM.displayDuration", _commandLineOverrides));
@@ -273,4 +280,3 @@ void ProjectMSDLApplication::ListAudioDevices(POCO_UNUSED const std::string& nam
 {
     _commandLineOverrides->setBool("audio.listDevices", true);
 }
-

--- a/src/RenderLoop.h
+++ b/src/RenderLoop.h
@@ -87,5 +87,7 @@ protected:
 
     ModifierKeyStates _keyStates; //!< Current "pressed" states of modifier keys
 
+    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _userConfig; //!< View of the "projectM" configuration subkey in the "user" configuration.
+
     Poco::Logger& _logger{Poco::Logger::get("RenderLoop")}; //!< The class logger.
 };

--- a/src/gui/SettingsWindow.cpp
+++ b/src/gui/SettingsWindow.cpp
@@ -106,6 +106,14 @@ void SettingsWindow::DrawProjectMSettingsTab()
             BooleanSetting("projectM.shuffleEnabled", true);
 
             ImGui::TableNextRow();
+            LabelWithTooltip("Skip To Dropped Presets", "If enabled, will skip to the new presets when preset(s) are dropped onto the window and added to the playlist");
+            BooleanSetting("projectM.skipToDropped", true);
+
+            ImGui::TableNextRow();
+            LabelWithTooltip("Dropped Folder Overrides Playlist", "When dropping a folder, clear the playlist and add all presets from the folder.");
+            BooleanSetting("projectM.droppedFolderOverride", false);
+
+            ImGui::TableNextRow();
             LabelWithTooltip("Preset Display Duration", "Time in seconds a preset will be displayed before it's switched.");
             DoubleSetting("projectM.displayDuration", 30.0, 1.0, 240.0);
 


### PR DESCRIPTION
I wanted a good first issue to acquaint myself with this project, and since one of the frustrating parts of the build/install process was figuring out how to load presets, I figured adding good drag & drop support would be useful (as per issue https://github.com/projectM-visualizer/frontend-sdl-cpp/issues/84).

SDL provides the drop event, so the implementation was fairly straightforward. The user can either drag & drop a preset file (or collection of preset files), or a folder containing presets. Preset files are files that end with '.milk' or '.prjm' (haven't seen or used prjm files but they are listed as supported in the projectM code). Dragging a file will immediately enqueue it on the next spot in the playlist, and dragging a folder will enqueue all presets in the folder (searched recursively).

I also added two configuration options to give more control to the user (split into a separate commit, as I had to add an additional include on the RenderLoop to access the configuration settings). There are now two additional UI/CLI settings:

skipToDropped (default: true)
When enabled, any dropped presets will be immediately skipped to. (They are always enqueued next after the current preset at the moment, but when this is true it will automatically skip to this next preset. This also accounts for shuffle being enabled, and will always make sure that the preset you dropped is immediately switched to.)
droppedFolderOverride (default: false)
When enabled, and a folder is dropped onto the window, the current playlist will be cleared and replaced with the contents of the folder. So if you have a playlist going and you drop a folder onto the window, the visualizer will switch and only iterate through the presets in that folder (recursively).

Resolves #84 
(This issue mentions that behavior should be different depending on if the playlist editor is open or not, but unless I'm missing something I couldn't find a GUI playlist editor, so I instead added the configuration options to determine the behavior for now).