### PR TITLE
Don't Crash When Config Values are Dynamic String Interpolations

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -121,7 +121,7 @@ int AudioCapture::GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList)
     // Check if configured device is a number or string
     try
     {
-        audioDeviceIndex = _config->getInt("device", -1);
+        audioDeviceIndex = _config->getInt("audio.device", -1);
         if (deviceList.find(audioDeviceIndex) == deviceList.end())
         {
             poco_debug(_logger,
@@ -131,7 +131,7 @@ int AudioCapture::GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList)
     }
     catch (Poco::SyntaxException& ex)
     {
-        auto audioDeviceName = _config->getString("device", "");
+        auto audioDeviceName = _config->getString("audio.device", "");
 
         poco_debug_f1(_logger, R"(audio.device is set to non-numerical value. Searching for device name "%s".)",
                       audioDeviceName);

--- a/src/gui/ProjectMGUI.h
+++ b/src/gui/ProjectMGUI.h
@@ -124,14 +124,14 @@ private:
 
     float _textScalingFactor{0.0f}; //!< The text scaling factor.
 
+    Poco::Logger& _logger{Poco::Logger::get("ProjectMGUI")}; //!< The class logger.
+
     MainMenu _mainMenu{*this};
-    SettingsWindow _settingsWindow{*this}; //!< The settings window.
+    SettingsWindow _settingsWindow{*this, _logger}; //!< The settings window.
     AboutWindow _aboutWindow{*this}; //!< The about window.
     HelpWindow _helpWindow; //!< Help window with shortcuts and tips.
 
     std::unique_ptr<ToastMessage> _toast; //!< Current toast to be displayed.
 
     bool _visible{false}; //!< Flag for settings window visibility.
-
-    Poco::Logger& _logger{Poco::Logger::get("ProjectMGUI")}; //!< The class logger.
 };

--- a/src/gui/SettingsWindow.h
+++ b/src/gui/SettingsWindow.h
@@ -4,6 +4,7 @@
 
 #include <Poco/Util/MapConfiguration.h>
 #include <Poco/Util/PropertyFileConfiguration.h>
+#include <Poco/Logger.h>
 
 #include <string>
 
@@ -15,7 +16,7 @@ class SettingsWindow
 public:
     SettingsWindow() = delete;
 
-    explicit SettingsWindow(ProjectMGUI& gui);
+    explicit SettingsWindow(ProjectMGUI& gui, Poco::Logger & logger);
 
     /**
      * @brief Displays the settings window.
@@ -134,6 +135,9 @@ private:
 
     Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> _userConfiguration;
     Poco::AutoPtr<Poco::Util::MapConfiguration> _commandLineConfiguration;
+    std::set<std::string> _suppressPropertyWarnings;
+
+    Poco::Logger & _logger;
 
     FileChooser _pathChooser{FileChooser::Mode::Directory}; //!< The file chooser dialog to select preset and texture paths.
 };


### PR DESCRIPTION
I figured out how to run a separate instance of the visualizer on each screen by leveraging `${application.argv[n]}` options in the `projectMSDL.properties` file, however this was causing the GUI to crash as it expects to read integer values for the screen, width, and height fields.  This change prevents the GUI from crashing, ignores the setting, and logs a warning about the errant property.

There is also a change renaming a reference from a `"device"` property ⇒ `"audio.device"`, this may be incorrect but the application seems to accept it and it's consistent with appearances of `"audio.device"` elsewhere in the repository.