### PR TITLE
Use C++17 to build if we find POCO 1.14 or higher.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ find_package(projectM4 REQUIRED COMPONENTS Playlist)
 find_package(SDL2 REQUIRED)
 find_package(Poco REQUIRED COMPONENTS JSON XML Util Foundation)
 
+if(Poco_VERSION VERSION_GREATER_EQUAL 1.14.0)
+    # POCO 1.14 requires at least C++17
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(ENABLE_FREETYPE)
     find_package(Freetype)
 endif()


### PR DESCRIPTION
POCO 1.14. now requires C++17 to be used. This application doesn't have this hard requirement, so we now adapt the build process accordingly to use C++17 if POCO 1.14.0 or higher is found.