### PR TITLE
Allow SDL to change channel count and log audio driver.

### DIFF
--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -55,6 +55,8 @@ void AudioCaptureImpl::StartRecording(projectm* projectMHandle, int audioDeviceI
     _projectMHandle = projectMHandle;
     _currentAudioDeviceIndex = audioDeviceIndex;
 
+    poco_debug_f1(_logger, "Using SDL audio driver \"%s\".", std::string(SDL_GetCurrentAudioDriver()));
+
     if (OpenAudioDevice())
     {
         SDL_PauseAudioDevice(_currentAudioDeviceID, false);
@@ -125,7 +127,7 @@ bool AudioCaptureImpl::OpenAudioDevice()
 
     // Will be NULL on error, which happens if the requested index is -1. This automatically selects the default device.
     auto deviceName = SDL_GetAudioDeviceName(_currentAudioDeviceIndex, true);
-    _currentAudioDeviceID = SDL_OpenAudioDevice(deviceName, true, &requestedSpecs, &actualSpecs, 0);
+    _currentAudioDeviceID = SDL_OpenAudioDevice(deviceName, true, &requestedSpecs, &actualSpecs, SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
 
     if (_currentAudioDeviceID == 0)
     {


### PR DESCRIPTION
We can use any number of channels, so SDL2 can just give us the proper channel count for the given device. Might also cause issues when using the sdl2-compat layer for SDL3, as it may not be able to "emulate" channels.

Also display the audio driver used by SDL in log level "debug".