### PR TITLE
Close previous SDL audio recording device when selecting a new device index.

### DIFF
--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -91,6 +91,7 @@ void AudioCaptureImpl::AudioDeviceIndex(int index)
 {
     if (index >= -1 && index < SDL_GetNumAudioDevices(true))
     {
+        StopRecording();
         _currentAudioDeviceIndex = index;
         StartRecording(_projectMHandle, index);
     }


### PR DESCRIPTION
(Partially) fixes issue #81 