### PR TITLE
Added SDL_HINT_APP_NAME, which is required for things like pipewire correctly recognizing the application name

### DIFF
--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -249,6 +249,8 @@ void SDLRenderingWindow::CreateSDLWindow()
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 #endif
 
+	SDL_SetHint(SDL_HINT_APP_NAME, "projectM");
+	
     _renderingWindow = SDL_CreateWindow("projectM", left, top, width, height,
                                         SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     if (!_renderingWindow)


### PR DESCRIPTION
Initially opened as PR #124 by @upcz, with the commits squashed.