### PR TITLE
Add option for building ImGui against PlutoSVG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(PACKAGING_CONFIG_FILE "${DEFAULT_PACKAGING_CONFIG}" CACHE FILEPATH "CPack co
 
 set(SDL2_LINKAGE "shared" CACHE STRING "Set to either shared or static to specify how libSDL2 should be linked. Defaults to shared.")
 option(ENABLE_FREETYPE "Use the Freetype font rendering library instead of the built-in stb_truetype if available" ON)
+option(ENABLE_PLUTOSVG "Use the PlutoSVG for better OpenType SVG font support" ON)
 
 
 set(PRESET_DIRS "" CACHE STRING "List of paths with presets. Will be installed in \"presets\" ")
@@ -115,6 +116,10 @@ endif()
 
 if(ENABLE_FREETYPE)
     find_package(Freetype)
+
+    if(Freetype_FOUND AND ENABLE_PLUTOSVG AND (Freetype_VERSION VERSION_GREATER_EQUAL "2.12"))
+        find_package(plutosvg)
+    endif()
 endif()
 
 include(SDL2Target)

--- a/ImGui.cmake
+++ b/ImGui.cmake
@@ -33,6 +33,20 @@ if(ENABLE_FREETYPE AND Freetype_FOUND)
             PUBLIC
             Freetype::Freetype
             )
+
+    if(plutosvg_FOUND)
+        if (TARGET plutosvg::plutosvg)
+            target_compile_definitions(ImGui
+                    PRIVATE
+                    IMGUI_ENABLE_FREETYPE_PLUTOSVG
+                    )
+
+            target_link_libraries(ImGui
+                    PUBLIC
+                    plutosvg::plutosvg
+                    )
+        endif()
+    endif()
 endif()
 
 target_include_directories(ImGui

--- a/dependencies_check.cmake
+++ b/dependencies_check.cmake
@@ -25,3 +25,13 @@ if(Poco_VERSION VERSION_GREATER_EQUAL 1.10.0 AND Poco_VERSION VERSION_LESS_EQUAL
     message(AUTHOR_WARNING "Poco versions 1.10.0 and 1.10.1 have a known issue with subsystem uninitialization order.\n"
             "It is HIGHLY recommended to use at least version 1.11.0, otherwise it can lead to crashes on application shutdown.")
 endif()
+
+if(ENABLE_PLUTOSVG)
+    if(NOT ENABLE_FREETYPE)
+        message(AUTHOR_WARNING "Freetype is not enabled. PlutoSVG will not be used.")
+    elseif(NOT Freetype_FOUND)
+        message(AUTHOR_WARNING "Freetype not found. PlutoSVG will not be used.")
+    elseif(Freetype_VERSION VERSION_LESS "2.12")
+        message(AUTHOR_WARNING "PlutoSVG requires Freetype 2.12 or higher. Version found: ${Freetype_VERSION}. PlutoSVG will not be used.")
+    endif()
+endif()


### PR DESCRIPTION
According to [ImGui's documentation](https://github.com/ocornut/imgui/tree/45acd5e0e82f4c954432533ae9985ff0e1aad6d5/misc/freetype#using-opentype-svg-fonts-svginot), building against PlutoSVG improves support for OpenType SVG fonts and may also improve performance loading these fonts.