### PR TITLE
Decouple audio capture from projectM wrapper + GHA fixes

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -19,8 +19,6 @@ void AudioCapture::initialize(Poco::Util::Application& app)
 {
     _config = app.config().createView("audio");
 
-    auto& projectMWrapper = app.getSubsystem<ProjectMWrapper>();
-
     if (!_impl)
     {
         _impl = new AudioCaptureImpl;
@@ -31,7 +29,7 @@ void AudioCapture::initialize(Poco::Util::Application& app)
 
     PrintDeviceList(deviceList);
 
-    _impl->StartRecording(projectMWrapper.ProjectM(), audioDeviceIndex);
+    _impl->StartRecording(audioDeviceIndex);
 }
 
 void AudioCapture::uninitialize()

--- a/src/AudioCaptureImpl_CoreAudioTap.h
+++ b/src/AudioCaptureImpl_CoreAudioTap.h
@@ -40,10 +40,9 @@ public:
 
     /**
      * @brief Starts capturing system audio and forwarding it to projectM.
-     * @param projectMHandle projectM instance handle that will receive the captured data.
      * @param audioDeviceIndex Ignored in v1 (single system-audio source).
      */
-    void StartRecording(projectm* projectMHandle, int audioDeviceIndex);
+    void StartRecording(int audioDeviceIndex);
 
     /**
      * @brief Stops capturing and tears down the tap and aggregate device.

--- a/src/AudioCaptureImpl_CoreAudioTap.mm
+++ b/src/AudioCaptureImpl_CoreAudioTap.mm
@@ -1,6 +1,8 @@
 #include "AudioCaptureImpl_CoreAudioTap.h"
 
-#include <projectM-4/projectM.h>
+#include "notifications/AudioDataAvailableNotification.h"
+
+#include <Poco/NotificationCenter.h>
 
 #import <CoreAudio/CoreAudio.h>
 #import <Foundation/Foundation.h>
@@ -26,9 +28,8 @@ std::map<int, std::string> CoreAudioTapCapture::AudioDeviceList()
     return {{-1, _systemAudioDeviceName}};
 }
 
-void CoreAudioTapCapture::StartRecording(projectm* projectMHandle, int audioDeviceIndex)
+void CoreAudioTapCapture::StartRecording(int audioDeviceIndex)
 {
-    _projectMHandle = projectMHandle;
     _currentAudioDeviceIndex = -1; // Only one source in v1.
 
     if (StartTap())
@@ -188,7 +189,6 @@ bool CoreAudioTapCapture::StartTap()
             // 4. Install the IO proc. Runs on Core Audio's realtime thread; keep it allocation-
             //    and lock-free. Core Audio delivers deinterleaved float buffers (one buffer per
             //    channel) for tap aggregates, so forward the first buffer's frames to projectM.
-            projectm* handle = _projectMHandle;
             uint32_t channels = _channels;
 
             status = AudioDeviceCreateIOProcIDWithBlock(
@@ -196,7 +196,7 @@ bool CoreAudioTapCapture::StartTap()
                 ^(const AudioTimeStamp* /*inNow*/, const AudioBufferList* inInputData,
                   const AudioTimeStamp* /*inInputTime*/, AudioBufferList* /*outOutputData*/,
                   const AudioTimeStamp* /*inOutputTime*/) {
-                  if (handle == nullptr || inInputData == nullptr || inInputData->mNumberBuffers == 0)
+                  if (inInputData == nullptr || inInputData->mNumberBuffers == 0)
                   {
                       return;
                   }
@@ -210,10 +210,10 @@ bool CoreAudioTapCapture::StartTap()
                   auto* samples = static_cast<float*>(buffer.mData);
                   // mNumberChannels reflects the interleaving of this buffer.
                   uint32_t bufferChannels = buffer.mNumberChannels > 0 ? buffer.mNumberChannels : channels;
-                  unsigned int frameCount = buffer.mDataByteSize / sizeof(float) / bufferChannels;
+                  unsigned int sampleCount = buffer.mDataByteSize / sizeof(float);
 
-                  projectm_pcm_add_float(handle, samples, frameCount,
-                                         static_cast<projectm_channels>(bufferChannels));
+                  Poco::NotificationCenter::defaultCenter().postNotification(
+                      new AudioDataAvailableNotification(bufferChannels, samples, sampleCount));
                 });
 
             if (status != noErr || _ioProcID == nullptr)

--- a/src/AudioCaptureImpl_SDL.cpp
+++ b/src/AudioCaptureImpl_SDL.cpp
@@ -1,11 +1,11 @@
 #include "AudioCaptureImpl_SDL.h"
 
+#include "notifications/AudioDataAvailableNotification.h"
+
+#include <Poco/NotificationCenter.h>
 #include <Poco/Util/Application.h>
 
-#include <projectM-4/projectM.h>
-
 AudioCaptureImpl::AudioCaptureImpl()
-    : _requestedSampleCount(projectm_pcm_get_max_samples())
 {
     auto targetFps = Poco::Util::Application::instance().config().getUInt("projectM.fps", 60);
     if (targetFps > 0)
@@ -50,9 +50,8 @@ std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
     return deviceList;
 }
 
-void AudioCaptureImpl::StartRecording(projectm* projectMHandle, int audioDeviceIndex)
+void AudioCaptureImpl::StartRecording(int audioDeviceIndex)
 {
-    _projectMHandle = projectMHandle;
     _currentAudioDeviceIndex = audioDeviceIndex;
 
     poco_debug_f1(_logger, "Using SDL audio driver \"%s\".", std::string(SDL_GetCurrentAudioDriver()));
@@ -84,7 +83,7 @@ void AudioCaptureImpl::NextAudioDevice()
     // Will wrap around to default capture device (-1).
     int nextAudioDeviceId = ((_currentAudioDeviceIndex + 2) % (SDL_GetNumAudioDevices(true) + 1)) - 1;
 
-    StartRecording(_projectMHandle, nextAudioDeviceId);
+    StartRecording(nextAudioDeviceId);
 }
 
 void AudioCaptureImpl::AudioDeviceIndex(int index)
@@ -93,7 +92,7 @@ void AudioCaptureImpl::AudioDeviceIndex(int index)
     {
         StopRecording();
         _currentAudioDeviceIndex = index;
-        StartRecording(_projectMHandle, index);
+        StartRecording(index);
     }
 }
 
@@ -153,10 +152,18 @@ bool AudioCaptureImpl::OpenAudioDevice()
 void AudioCaptureImpl::AudioInputCallback(void* userData, unsigned char* stream, int len)
 {
     poco_assert_dbg(userData);
+
+    if (len < sizeof(float))
+    {
+        return;
+    }
+
     auto instance = reinterpret_cast<AudioCaptureImpl*>(userData);
 
-    unsigned int samples = len / sizeof(float) / instance->_channels;
+    unsigned int samples = len / sizeof(float);
 
-    projectm_pcm_add_float(instance->_projectMHandle, reinterpret_cast<float*>(stream), samples,
-                           static_cast<projectm_channels>(instance->_channels));
+    Poco::NotificationCenter::defaultCenter().postNotification(
+        new AudioDataAvailableNotification(instance->_channels,
+                                           reinterpret_cast<float*>(stream),
+                                           samples));
 }

--- a/src/AudioCaptureImpl_SDL.h
+++ b/src/AudioCaptureImpl_SDL.h
@@ -5,7 +5,6 @@
 #include <Poco/Logger.h>
 
 #include <string>
-#include <vector>
 
 class projectm;
 
@@ -29,11 +28,10 @@ public:
 
     /**
      * @brief Starts audio capturing with the first available device.
-     * @param projectMHandle projectM instance handle that will receive the captured data.
      * @param audioDeviceIndex The initial audio device ID to capture from. Use -1 to select the implementation's
      *                      default device.
      */
-    void StartRecording(projectm* projectMHandle, int audioDeviceIndex);
+    void StartRecording(int audioDeviceIndex);
 
     /**
      * @brief Stops audio recording.
@@ -66,9 +64,7 @@ public:
     /**
      * @brief Asks the capture client to fill projectM's audio buffer for the next frame.
      *
-     * As of now, SDL uses async callbacks to directly fill projectM's audio buffer.
-     *
-     * @todo Store audio samples internally and push them to projectM when requested.
+     * SDL uses async callbacks to directly fill the staging audio buffer(s) as soon as new data is available.
      */
     void FillBuffer(){};
 
@@ -90,7 +86,6 @@ protected:
      */
     static void AudioInputCallback(void* userData, unsigned char* stream, int len);
 
-    projectm* _projectMHandle{nullptr}; //!< Handle if the projectM instance that will receive the audio data.
     int32_t _currentAudioDeviceIndex{-1}; //!< Currently selected audio device index.
     SDL_AudioDeviceID _currentAudioDeviceID{0}; //!< Device ID of the currently opened audio device.
     uint32_t _channels{2};

--- a/src/AudioCaptureImpl_WASAPI.cpp
+++ b/src/AudioCaptureImpl_WASAPI.cpp
@@ -1,9 +1,10 @@
 #include "AudioCaptureImpl_WASAPI.h"
 
-#include <projectM-4/projectM.h>
+#include "notifications/AudioDataAvailableNotification.h"
 
 #include <Poco/UnicodeConverter.h>
 
+#include <Poco/NotificationCenter.h>
 #include <functiondiscoverykeys_devpkey.h>
 #include <mmdeviceapi.h>
 #include <objbase.h>
@@ -42,9 +43,8 @@ std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
     return deviceList;
 }
 
-void AudioCaptureImpl::StartRecording(projectm* projectMHandle, int audioDeviceIndex)
+void AudioCaptureImpl::StartRecording(int audioDeviceIndex)
 {
-    _projectMHandle = projectMHandle;
     _currentAudioDeviceIndex = audioDeviceIndex;
 
     _isCapturing = true;
@@ -74,7 +74,7 @@ void AudioCaptureImpl::NextAudioDevice()
     // Will wrap around to loopback capture device (-1).
     int nextAudioDeviceId = ((_currentAudioDeviceIndex + 2) % (static_cast<int>(captureDevices.size()) + 1)) - 1;
 
-    StartRecording(_projectMHandle, nextAudioDeviceId);
+    StartRecording(nextAudioDeviceId);
 }
 
 void AudioCaptureImpl::AudioDeviceIndex(int index)
@@ -87,7 +87,7 @@ void AudioCaptureImpl::AudioDeviceIndex(int index)
     {
         _currentAudioDeviceIndex = index;
         StopRecording();
-        StartRecording(_projectMHandle, index);
+        StartRecording(index);
     }
 }
 
@@ -447,7 +447,10 @@ void AudioCaptureImpl::CaptureThread()
 
                 if (framesAvailable > 0 && data != nullptr)
                 {
-                    projectm_pcm_add_float(_projectMHandle, reinterpret_cast<float*>(data), framesAvailable, static_cast<projectm_channels>(_channels));
+                    Poco::NotificationCenter::defaultCenter().postNotification(
+                        new AudioDataAvailableNotification(_channels,
+                                                           reinterpret_cast<float*>(data),
+                                                           framesAvailable * _channels));
                 }
 
                 _audioCaptureClient->ReleaseBuffer(framesAvailable);

--- a/src/AudioCaptureImpl_WASAPI.h
+++ b/src/AudioCaptureImpl_WASAPI.h
@@ -45,11 +45,10 @@ public:
 
     /**
      * @brief Starts audio capturing with the first available device.
-     * @param projectMHandle projectM instance handle that will receive the captured data.
      * @param audioDeviceIndex The initial audio device ID to capture from. Use -1 to select the implementation's
      *                      default device.
      */
-    void StartRecording(projectm* projectMHandle, int audioDeviceIndex);
+    void StartRecording(int audioDeviceIndex);
 
     /**
      * @brief Stops audio recording.

--- a/src/AudioCaptureImpl_macOS.h
+++ b/src/AudioCaptureImpl_macOS.h
@@ -30,7 +30,7 @@ public:
 
     std::map<int, std::string> AudioDeviceList();
 
-    void StartRecording(projectm* projectMHandle, int audioDeviceIndex);
+    void StartRecording(int audioDeviceIndex);
 
     void StopRecording();
 

--- a/src/AudioCaptureImpl_macOS.mm
+++ b/src/AudioCaptureImpl_macOS.mm
@@ -42,14 +42,14 @@ std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
     return _sdl->AudioDeviceList();
 }
 
-void AudioCaptureImpl::StartRecording(projectm* projectMHandle, int audioDeviceIndex)
+void AudioCaptureImpl::StartRecording(int audioDeviceIndex)
 {
     if (_tap)
     {
-        _tap->StartRecording(projectMHandle, audioDeviceIndex);
+        _tap->StartRecording(audioDeviceIndex);
         return;
     }
-    _sdl->StartRecording(projectMHandle, audioDeviceIndex);
+    _sdl->StartRecording(audioDeviceIndex);
 }
 
 void AudioCaptureImpl::StopRecording()

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -108,6 +108,7 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
     }
 
     Poco::NotificationCenter::defaultCenter().addObserver(_playbackControlNotificationObserver);
+    Poco::NotificationCenter::defaultCenter().addObserver(_audioDataAvailableNotificationObserver);
 
     // Observe user configuration changes (set via the settings window)
     _userConfig->propertyChanged += Poco::delegate(this, &ProjectMWrapper::OnConfigurationPropertyChanged);
@@ -119,6 +120,7 @@ void ProjectMWrapper::uninitialize()
     _userConfig->propertyRemoved -= Poco::delegate(this, &ProjectMWrapper::OnConfigurationPropertyRemoved);
     _userConfig->propertyChanged -= Poco::delegate(this, &ProjectMWrapper::OnConfigurationPropertyChanged);
     Poco::NotificationCenter::defaultCenter().removeObserver(_playbackControlNotificationObserver);
+    Poco::NotificationCenter::defaultCenter().removeObserver(_audioDataAvailableNotificationObserver);
 
     if (_projectM)
     {
@@ -153,7 +155,7 @@ void ProjectMWrapper::UpdateRealFPS(float fps)
     projectm_set_fps(_projectM, static_cast<uint32_t>(std::round(fps)));
 }
 
-void ProjectMWrapper::RenderFrame() const
+void ProjectMWrapper::RenderFrame()
 {
     glClearColor(0.0, 0.0, 0.0, 0.0);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -165,6 +167,16 @@ void ProjectMWrapper::RenderFrame() const
         currentMeshY != _projectMConfigView->getInt("meshY", 125))
     {
         projectm_set_mesh_size(_projectM, _projectMConfigView->getInt("meshX", 220), _projectMConfigView->getInt("meshY", 125));
+    }
+
+    // Add new audio data to the instance from the staging buffer
+    {
+        Poco::ScopedLock lock(_audioBufferMutex);
+        if (!_audioStagingBuffer.empty())
+        {
+            projectm_pcm_add_float(_projectM, _audioStagingBuffer.data(), _audioStagingBuffer.size() / _audioChannels, static_cast<projectm_channels>(_audioChannels));
+            _audioStagingBuffer.clear();
+        }
     }
 
     projectm_opengl_render_frame(_projectM);
@@ -261,6 +273,20 @@ void ProjectMWrapper::PlaybackControlNotificationHandler(const Poco::AutoPtr<Pla
             break;
         }
     }
+}
+
+void ProjectMWrapper::AudioDataAvailableNotificationHandler(const Poco::AutoPtr<AudioDataAvailableNotification>& notification)
+{
+    Poco::ScopedLock lock(_audioBufferMutex);
+
+    // Clear existing buffer data if channel count differs, e.g. if audio device has changed
+    if (_audioChannels != notification->Channels())
+    {
+        _audioChannels = notification->Channels();
+        _audioStagingBuffer.clear();
+    }
+
+    std::copy(notification->Samples().cbegin(), notification->Samples().cend(), std::back_inserter(_audioStagingBuffer));
 }
 
 std::vector<std::string> ProjectMWrapper::GetPathListWithDefault(const std::string& baseKey, const std::string& defaultPath)

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "notifications/AudioDataAvailableNotification.h"
 #include "notifications/PlaybackControlNotification.h"
 
 #include <projectM-4/projectM.h>
@@ -37,7 +38,7 @@ public:
     /**
      * Renders a single projectM frame.
      */
-    void RenderFrame() const;
+    void RenderFrame();
 
     /**
      * @brief Returns the targeted FPS value.
@@ -91,6 +92,8 @@ private:
 
     void PlaybackControlNotificationHandler(const Poco::AutoPtr<PlaybackControlNotification>& notification);
 
+    void AudioDataAvailableNotificationHandler(const Poco::AutoPtr<AudioDataAvailableNotification>& notification);
+
     std::vector<std::string> GetPathListWithDefault(const std::string& baseKey, const std::string& defaultPath);
 
     /**
@@ -111,7 +114,12 @@ private:
     projectm_handle _projectM{nullptr}; //!< Pointer to the projectM instance used by the application.
     projectm_playlist_handle _playlist{nullptr}; //!< Pointer to the projectM playlist manager instance.
 
+    uint32_t _audioChannels{0}; //!< Number of audio channels of the current capture device.
+    std::vector<float> _audioStagingBuffer; //!< Buffer which receives audio data from the capture implementation.
+    mutable Poco::Mutex _audioBufferMutex; //!< Mutex protecting access to the audio staging buffer.
+
     Poco::NObserver<ProjectMWrapper, PlaybackControlNotification> _playbackControlNotificationObserver{*this, &ProjectMWrapper::PlaybackControlNotificationHandler};
+    Poco::NObserver<ProjectMWrapper, AudioDataAvailableNotification> _audioDataAvailableNotificationObserver{*this, &ProjectMWrapper::AudioDataAvailableNotificationHandler};
 
     Poco::Logger& _logger{Poco::Logger::get("SDLRenderingWindow")}; //!< The class logger.
 };

--- a/src/notifications/AudioDataAvailableNotification.cpp
+++ b/src/notifications/AudioDataAvailableNotification.cpp
@@ -1,0 +1,32 @@
+#include "AudioDataAvailableNotification.h"
+
+#include <Poco/Bugcheck.h>
+
+#include <cstring>
+
+std::string AudioDataAvailableNotification::name() const
+{
+    return "AudioDataAvailableNotification";
+}
+
+AudioDataAvailableNotification::AudioDataAvailableNotification(uint32_t channels, const float* samples, const uint32_t sampleCount)
+    : _channels(channels)
+{
+    poco_assert(channels > 0);
+    poco_assert(samples != nullptr);
+    poco_assert(sampleCount != 0);
+    poco_assert(sampleCount % channels == 0);
+
+    _samples.resize(sampleCount);
+    std::memcpy(_samples.data(), samples, sampleCount * sizeof(float));
+}
+
+uint32_t AudioDataAvailableNotification::Channels() const
+{
+    return _channels;
+}
+
+const std::vector<float>& AudioDataAvailableNotification::Samples() const
+{
+    return _samples;
+}

--- a/src/notifications/AudioDataAvailableNotification.h
+++ b/src/notifications/AudioDataAvailableNotification.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Poco/Notification.h>
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * @brief Passes new audio data to all active projectM instances.
+ * @note Channels must be >0 and samples must contain at least one audio frame/sample.
+ */
+class AudioDataAvailableNotification : public Poco::Notification
+{
+public:
+    std::string name() const override;
+
+    AudioDataAvailableNotification() = delete;
+
+    /**
+     * @brief Creates a new AudioDataAvailableNotification instance
+     * The number of @a samples must be divisible by @a channels.
+     * @param channels The channel count of the current capture device.
+     * @param samples The new audio samples captured from the active audio device.
+     * @param sampleCount The number of float samples passed to @a samples.
+     */
+    explicit AudioDataAvailableNotification(uint32_t channels, const float* samples, uint32_t sampleCount);
+
+    /**
+     * Returns the number of audio channels of the recording device.
+     * @return The number of audio channels of the recording device.
+     */
+    [[nodiscard]] uint32_t Channels() const;
+
+    /**
+     * Returns the new audio samples captured from the active audio device.
+     * @return The new audio samples captured from the active audio device.
+     */
+    [[nodiscard]] const std::vector<float>& Samples() const;
+
+private:
+    uint32_t _channels; //!< Number of audio channels of the capture device.
+    std::vector<float> _samples; //!< The new audio samples, containing frames x channels floats.
+};

--- a/src/notifications/CMakeLists.txt
+++ b/src/notifications/CMakeLists.txt
@@ -1,7 +1,15 @@
 add_library(ProjectMSDL-Notifications STATIC
+        AudioDataAvailableNotification.cpp
+        AudioDataAvailableNotification.h
         DisplayToastNotification.cpp
         DisplayToastNotification.h
-        QuitNotification.cpp QuitNotification.h PlaybackControlNotification.cpp PlaybackControlNotification.h UpdateWindowTitleNotification.cpp UpdateWindowTitleNotification.h)
+        PlaybackControlNotification.cpp
+        PlaybackControlNotification.h
+        QuitNotification.cpp
+        QuitNotification.h
+        UpdateWindowTitleNotification.cpp
+        UpdateWindowTitleNotification.h
+        )
 
 target_include_directories(ProjectMSDL-Notifications
         PRIVATE


### PR DESCRIPTION
This changeset removes the direct projectM dependency in the audio capture implementations, using notifications instead.

This provides a few advantages:
- No need to pass in/know the projectM handle or use projectM API functions in the audio capture classes.
- Since a notification can have multiple subscribers, which are notified in sequence, this allows to pass captured audio to multiple projectM instances without the audio capture driver needing to know the number of recipients (can be >=0).
- Audio data is now transferred to a buffer in the ProjectMWrapper class in a thread-safe manner, removing any possible race conditions.
- This change allows to have more than one projectM instance at the same time, e.g. to implement a multi-window mode or show a small UI window with an animated preset preview.

The audio capture driver can still capture asynchronously in a separate thread or read the audio data when its `FillBuffer()` method is called. Audio data is transferred to the projectM instance immediately before the frame render function is called.

Edit: merged the build fixed to master separately to re-enable build checks in other branches.